### PR TITLE
Overhaul logging and queue management.

### DIFF
--- a/movencoder2/MEAudioConverter.m
+++ b/movencoder2/MEAudioConverter.m
@@ -26,6 +26,7 @@
 
 #import "MECommon.h"
 #import "MEAudioConverter.h"
+#import "MESecureLogging.h"
 #include <unistd.h>
 
 /* =================================================================================== */
@@ -480,7 +481,7 @@ cleanup:
             if (!self->_audioConverter) {
                 self.failed = YES;
                 if (self.verbose) {
-                    NSLog(@"[MEAudioConverter] Failed to create AVAudioConverter");
+                    SecureErrorLog(@"Failed to create AVAudioConverter");
                 }
                 return;
             }
@@ -551,7 +552,7 @@ cleanup:
                     }
                 } else if (convertError) {
                     if (self.verbose) {
-                        NSLog(@"[MEAudioConverter] Audio conversion error: %@", convertError);
+                        SecureErrorLogf(@"Audio conversion error: %@", convertError);
                     }
                     self.failed = YES;
                 }
@@ -716,7 +717,7 @@ cleanup:
         default:
             // Unsupported format, log warning
             if (self.verbose) {
-                NSLog(@"[MEAudioConverter] Volume adjustment not supported for format: %d", (int)buffer.format.commonFormat);
+                SecureLogf(@"Volume adjustment not supported for format: %d", (int)buffer.format.commonFormat);
             }
             break;
     }

--- a/movencoder2/MECommon.h
+++ b/movencoder2/MECommon.h
@@ -29,13 +29,14 @@
 
 @import Foundation;
 @import AVFoundation;
+#import "MESecureLogging.h"
 
 /* =================================================================================== */
 // MARK: - Common Macros
 /* =================================================================================== */
 
 #ifndef ALog
-#define ALog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__)
+#define ALog(fmt, ...) SecureDebugLogf((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__)
 #endif
 
 /* =================================================================================== */

--- a/movencoder2/MESecureLogging.h
+++ b/movencoder2/MESecureLogging.h
@@ -10,36 +10,17 @@
 
 #import <Foundation/Foundation.h>
 
-/**
- * Secure logging functions to prevent format string attacks
- * These functions ensure that user-controlled strings cannot be used as format strings
- */
+// Secure logging functions (prevent format-string attacks)
+void SecureLog(NSString* message);
+void SecureErrorLog(NSString* message);
+void SecureDebugLog(NSString* message);
 
-/**
- * Secure NSLog wrapper that prevents format string attacks
- * Always uses a fixed format string with %@ placeholder for the message
- */
-#define SecureNSLog(message, ...) \
-    NSLog(@"[SECURE] %@", [NSString stringWithFormat:(message), ##__VA_ARGS__])
+// Formatted logging (internally sanitized)
+void SecureLogf(NSString* format, ...) NS_FORMAT_FUNCTION(1,2);
+void SecureErrorLogf(NSString* format, ...) NS_FORMAT_FUNCTION(1,2);
+void SecureDebugLogf(NSString* format, ...) NS_FORMAT_FUNCTION(1,2);
 
-/**
- * Secure error logging function
- * Ensures error messages cannot contain format string vulnerabilities
- */
-#define SecureErrorLog(message, ...) \
-    NSLog(@"[ERROR] %@", [NSString stringWithFormat:(message), ##__VA_ARGS__])
-
-/**
- * Secure debug logging function
- * For debugging information with format string protection
- */
-#define SecureDebugLog(message, ...) \
-    NSLog(@"[DEBUG] %@", [NSString stringWithFormat:(message), ##__VA_ARGS__])
-
-/**
- * Sanitize a string to remove potential format string specifiers
- * Replaces % with %% to prevent format string interpretation
- */
+// String sanitization
 NSString* sanitizeLogString(NSString* input);
 
 #endif /* MESecureLogging_h */

--- a/movencoder2/MESecureLogging.m
+++ b/movencoder2/MESecureLogging.m
@@ -6,20 +6,65 @@
 //
 
 #import "MESecureLogging.h"
+#import <stdarg.h>
+
+static NSString* sanitizeForOutput(NSString* s) {
+    if (!s) return @"(null)";
+    // Replace actual control characters with escaped representations to avoid multiline/log injection
+    NSString* out = [s stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"];
+    out = [out stringByReplacingOccurrencesOfString:@"\r" withString:@"\\r"];
+    out = [out stringByReplacingOccurrencesOfString:@"\t" withString:@"\\t"];
+    return out;
+}
 
 NSString* sanitizeLogString(NSString* input) {
-    if (!input) {
-        return @"(null)";
-    }
-    
-    // Replace % with %% to prevent format string interpretation
-    // This ensures that user-controlled strings cannot contain format specifiers
-    NSString* sanitized = [input stringByReplacingOccurrencesOfString:@"%" withString:@"%%"];
-    
-    // Also sanitize common format specifiers that might be used in attacks
-    // Note: This is defensive - the main protection is using fixed format strings
-    sanitized = [sanitized stringByReplacingOccurrencesOfString:@"\\n" withString:@"\\\\n"];
-    sanitized = [sanitized stringByReplacingOccurrencesOfString:@"\\t" withString:@"\\\\t"];
-    
-    return sanitized;
+    if (!input) return @"(null)";
+    // Legacy behavior: escape '%' so that if this string was (incorrectly) used as a format it won't be interpreted.
+    // Also escape backslash-newline/tab sequences.
+    NSString* s = [input stringByReplacingOccurrencesOfString:@"%" withString:@"%%"];
+    s = [s stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"];
+    s = [s stringByReplacingOccurrencesOfString:@"\t" withString:@"\\t"];
+    return s;
+}
+
+void SecureLog(NSString* message) {
+    NSString* out = sanitizeForOutput(message);
+    NSLog(@"[INFO] %@", out);
+}
+
+void SecureErrorLog(NSString* message) {
+    NSString* out = sanitizeForOutput(message);
+    NSLog(@"[ERROR] %@", out);
+}
+
+void SecureDebugLog(NSString* message) {
+    NSString* out = sanitizeForOutput(message);
+    NSLog(@"[DEBUG] %@", out);
+}
+
+void SecureLogf(NSString* format, ...) {
+    va_list args;
+    va_start(args, format);
+    NSString* formatted = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+    NSString* out = sanitizeForOutput(formatted);
+    NSLog(@"[INFO] %@", out);
+}
+
+void SecureErrorLogf(NSString* format, ...) {
+    va_list args;
+    va_start(args, format);
+    NSString* formatted = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+    NSString* out = sanitizeForOutput(formatted);
+    NSLog(@"[ERROR] %@", out);
+}
+
+void SecureDebugLogf(NSString* format, ...) {
+    va_list args;
+    va_start(args, format);
+    NSString* formatted = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+    NSString* out = sanitizeForOutput(formatted);
+    NSLog(@"[DEBUG] %@", out);
 }

--- a/movencoder2/METranscoder+prepareChannels.m
+++ b/movencoder2/METranscoder+prepareChannels.m
@@ -25,6 +25,7 @@
  */
 
 #import "METranscoder+Internal.h"
+#import "MESecureLogging.h"
 
 /* =================================================================================== */
 // MARK: -
@@ -98,7 +99,7 @@ uint32_t formatIDFor(NSString* fourCC)
         BOOL awOK = [aw canAddInput:awInput];
         
         if (!(arOK && awOK)) {
-            NSLog(@"[METranscoder] Skipping track(%d) - unsupported", track.trackID);
+            SecureLogf(@"Skipping track(%d) - unsupported", track.trackID);
             continue;
         }
         
@@ -452,7 +453,7 @@ uint32_t formatIDFor(NSString* fourCC)
                     }
                 }
                 awInputSetting[AVEncoderBitRateKey] = prev;
-                NSLog(@"[METranscoder] Bitrate adjustment to %@ from %@", prev, @(self.audioBitRate));
+                SecureLogf(@"Bitrate adjustment to %@ from %@", prev, @(self.audioBitRate));
             }
         }
         
@@ -491,7 +492,7 @@ uint32_t formatIDFor(NSString* fourCC)
         CMFormatDescriptionRef desc = (__bridge CMFormatDescriptionRef) descArray[0];
         const AudioStreamBasicDescription* asbd = CMAudioFormatDescriptionGetStreamBasicDescription(desc);
         if (!asbd) {
-            NSLog(@"[METranscoder] Skipping audio track(%d) - no audio format description", track.trackID);
+            SecureErrorLogf(@"Skipping audio track(%d) - no audio format description", track.trackID);
             continue;
         }
         
@@ -548,7 +549,7 @@ uint32_t formatIDFor(NSString* fourCC)
                 avacSrcLayout = [AVAudioChannelLayout layoutWithLayoutTag:srcTag];
                 avacDstLayout = [AVAudioChannelLayout layoutWithLayoutTag:dstTag];
             } else {
-                NSLog(@"[METranscoder] Skipping audio track(%d) - unsupported channel count %d", track.trackID, numChannel);
+                SecureErrorLogf(@"Skipping audio track(%d) - unsupported channel count %d", track.trackID, numChannel);
                 continue;
             }
         }
@@ -567,7 +568,7 @@ uint32_t formatIDFor(NSString* fourCC)
         }
         
         if (!avacSrcLayout || !avacDstLayout) {
-            NSLog(@"[METranscoder] Skipping audio track(%d) - channel layout creation failed", track.trackID);
+            SecureErrorLogf(@"Skipping audio track(%d) - channel layout creation failed", track.trackID);
             continue;
         }
         
@@ -628,7 +629,7 @@ uint32_t formatIDFor(NSString* fourCC)
         AVAudioFormat* dstFormat = [[AVAudioFormat alloc] initWithSettings:awInputSetting];
         
         if (!srcFormat || !intermediateFormat || !dstFormat) {
-            NSLog(@"[METranscoder] Skipping audio track(%d) - unsupported audio format detected", track.trackID);
+            SecureErrorLogf(@"Skipping audio track(%d) - unsupported audio format detected", track.trackID);
             continue;
         }
         
@@ -653,12 +654,12 @@ uint32_t formatIDFor(NSString* fourCC)
                     }
                     
                     awInputSetting[AVEncoderBitRateKey] = closestBitrate;
-                    NSLog(@"[METranscoder] Bitrate adjustment to %@ from %@", closestBitrate, @(self.audioBitRate));
+                    SecureLogf(@"Bitrate adjustment to %@ from %@", closestBitrate, @(self.audioBitRate));
                     
                     // Recreate destination format with adjusted bitrate
                     dstFormat = [[AVAudioFormat alloc] initWithSettings:awInputSetting];
                     if (!dstFormat) {
-                        NSLog(@"[METranscoder] Skipping audio track(%d) - destination format recreation failed", track.trackID);
+                        SecureErrorLogf(@"Skipping audio track(%d) - destination format recreation failed", track.trackID);
                         continue;
                     }
                 }
@@ -682,7 +683,7 @@ uint32_t formatIDFor(NSString* fourCC)
         AVAssetReaderOutput* arOutput = [AVAssetReaderTrackOutput assetReaderTrackOutputWithTrack:track
                                                                                    outputSettings:arOutputSetting];
         if (![ar canAddOutput:arOutput]) {
-            NSLog(@"[METranscoder] Skipping audio track(%d) - reader output not supported", track.trackID);
+            SecureErrorLogf(@"Skipping audio track(%d) - reader output not supported", track.trackID);
             continue;
         }
         [ar addOutput:arOutput];
@@ -699,7 +700,7 @@ uint32_t formatIDFor(NSString* fourCC)
         AVAssetWriterInput* awInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio
                                                                          outputSettings:awInputSetting];
         if (![aw canAddInput:awInput]) {
-            NSLog(@"[METranscoder] Skipping audio track(%d) - writer input not supported", track.trackID);
+            SecureErrorLogf(@"Skipping audio track(%d) - writer input not supported", track.trackID);
             continue;
         }
         [aw addInput:awInput];

--- a/movencoder2/METranscoder+prepareChannels.m
+++ b/movencoder2/METranscoder+prepareChannels.m
@@ -63,7 +63,7 @@ uint32_t formatIDFor(NSString* fourCC)
         
         // Safe access using validated bounds
         uint32_t c0 = (unsigned char)str[0];
-        uint32_t c1 = (unsigned char)str[1]; 
+        uint32_t c1 = (unsigned char)str[1];
         uint32_t c2 = (unsigned char)str[2];
         uint32_t c3 = (unsigned char)str[3];
         result = (c0<<24) + (c1<<16) + (c2<<8) + (c3);
@@ -155,7 +155,11 @@ uint32_t formatIDFor(NSString* fourCC)
         CMFormatDescriptionRef desc = (__bridge CMFormatDescriptionRef) descArray[0];
         
         const AudioStreamBasicDescription* asbd = CMAudioFormatDescriptionGetStreamBasicDescription(desc);
-        assert(asbd != NULL);
+        if (!asbd) {
+            SecureErrorLogf(@"Skipping audio track(%d) - no audio format description", track.trackID);
+            continue;
+        }
+        
         sampleRate = (int)asbd->mSampleRate;
         numChannel = (int)asbd->mChannelsPerFrame;
         

--- a/movencoder2/METranscoder+prepareChannels.m
+++ b/movencoder2/METranscoder+prepareChannels.m
@@ -95,16 +95,20 @@ uint32_t formatIDFor(NSString* fourCC)
             awInput.mediaTimeScale = track.naturalTimeScale;
         }
         
-        BOOL arOK = [ar canAddOutput:arOutput];
-        BOOL awOK = [aw canAddInput:awInput];
-        
+        __block BOOL arOK = FALSE;
+        __block BOOL awOK = FALSE;
+        dispatch_sync(self.processQueue, ^{
+            arOK = [ar canAddOutput:arOutput];
+            awOK = [aw canAddInput:awInput];
+        });
         if (!(arOK && awOK)) {
             SecureLogf(@"Skipping track(%d) - unsupported", track.trackID);
             continue;
         }
-        
-        [ar addOutput:arOutput];
-        [aw addInput:awInput];
+        dispatch_sync(self.processQueue, ^{
+            [ar addOutput:arOutput];
+            [aw addInput:awInput];
+        });
         
         // channel
         SBChannel* sbcCopy = [SBChannel sbChannelWithProducerME:(MEOutput*)arOutput
@@ -142,7 +146,17 @@ uint32_t formatIDFor(NSString* fourCC)
         arOutputSetting[AVFormatIDKey] = @(kAudioFormatLinearPCM);
         AVAssetReaderOutput* arOutput = [AVAssetReaderTrackOutput assetReaderTrackOutputWithTrack:track
                                                                                    outputSettings:arOutputSetting];
-        [ar addOutput:arOutput];
+        __block BOOL arOK = FALSE;
+        dispatch_sync(self.processQueue, ^{
+            arOK = [ar canAddOutput:arOutput];
+        });
+        if (!arOK) {
+            SecureLogf(@"Skipping audio track(%d) - unsupported", track.trackID);
+            continue;
+        }
+        dispatch_sync(self.processQueue, ^{
+            [ar addOutput:arOutput];
+        });
         
         // preserve original sampleRate, numChannel, and audioChannelLayout(best effort)
         int sampleRate = 0;
@@ -464,7 +478,17 @@ uint32_t formatIDFor(NSString* fourCC)
         AVAssetWriterInput* awInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio
                                                                          outputSettings:awInputSetting];
         // awInput.mediaTimeScale = track.naturalTimeScale; // Audio track is unable to change
-        [aw addInput:awInput];
+        __block BOOL awOK = FALSE;
+        dispatch_sync(self.processQueue, ^{
+            awOK = [aw canAddInput:awInput];
+        });
+        if (!awOK) {
+            SecureLogf(@"Skipping audio track(%d) - unsupported", track.trackID);
+            continue;
+        }
+        dispatch_sync(self.processQueue, ^{
+            [aw addInput:awInput];
+        });
         
         // channel
         SBChannel* sbcAudio = [SBChannel sbChannelWithProducerME:(MEOutput*)arOutput
@@ -686,11 +710,17 @@ uint32_t formatIDFor(NSString* fourCC)
         // Create AVAssetReaderTrackOutput
         AVAssetReaderOutput* arOutput = [AVAssetReaderTrackOutput assetReaderTrackOutputWithTrack:track
                                                                                    outputSettings:arOutputSetting];
-        if (![ar canAddOutput:arOutput]) {
+        __block BOOL arOK = FALSE;
+        dispatch_sync(self.processQueue, ^{
+            arOK = [ar canAddOutput:arOutput];
+        });
+        if (!arOK) {
             SecureErrorLogf(@"Skipping audio track(%d) - reader output not supported", track.trackID);
             continue;
         }
-        [ar addOutput:arOutput];
+        dispatch_sync(self.processQueue, ^{
+            [ar addOutput:arOutput];
+        });
         
         // Source channel: AVAssetReaderOutput -> MEAudioConverter (acting as MEInput)
         SBChannel* sbcMEInput = [SBChannel sbChannelWithProducerME:(MEOutput*)arOutput
@@ -703,11 +733,17 @@ uint32_t formatIDFor(NSString* fourCC)
         // Create AVAssetWriterInput
         AVAssetWriterInput* awInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio
                                                                          outputSettings:awInputSetting];
-        if (![aw canAddInput:awInput]) {
+        __block BOOL awOK = FALSE;
+        dispatch_sync(self.processQueue, ^{
+            awOK = [aw canAddInput:awInput];
+        });
+        if (!awOK) {
             SecureErrorLogf(@"Skipping audio track(%d) - writer input not supported", track.trackID);
             continue;
         }
-        [aw addInput:awInput];
+        dispatch_sync(self.processQueue, ^{
+            [aw addInput:awInput];
+        });
         
         // Destination channel: MEAudioConverter (acting as MEOutput) -> AVAssetWriterInput
         SBChannel* sbcMEOutput = [SBChannel sbChannelWithProducerME:(MEOutput*)audioConverter
@@ -911,14 +947,34 @@ end:
         arOutputSetting[(__bridge NSString*)kCVPixelBufferPixelFormatTypeKey] = @(kCVPixelFormatType_422YpCbCr8);
         AVAssetReaderOutput* arOutput = [AVAssetReaderTrackOutput assetReaderTrackOutputWithTrack:track
                                                                                    outputSettings:arOutputSetting];
-        [ar addOutput:arOutput];
+        __block BOOL arOK = FALSE;
+        dispatch_sync(self.processQueue, ^{
+            arOK = [ar canAddOutput:arOutput];
+        });
+        if (!arOK) {
+            SecureErrorLogf(@"Skipping video track(%d) - reader output not supported", track.trackID);
+            continue;
+        }
+        dispatch_sync(self.processQueue, ^{
+            [ar addOutput:arOutput];
+        });
         
         //
         NSMutableDictionary<NSString*,id> * awInputSetting = [self videoCompressionSettingFor:track];
         AVAssetWriterInput* awInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo
                                                                          outputSettings:awInputSetting];
         awInput.mediaTimeScale = track.naturalTimeScale;
-        [aw addInput:awInput];
+        __block BOOL awOK = FALSE;
+        dispatch_sync(self.processQueue, ^{
+            awOK = [aw canAddInput:awInput];
+        });
+        if (!awOK) {
+            SecureErrorLogf(@"Skipping video track(%d) - writer input not supported", track.trackID);
+            continue;
+        }
+        dispatch_sync(self.processQueue, ^{
+            [aw addInput:awInput];
+        });
         
         // channel
         SBChannel* sbcVideo = [SBChannel sbChannelWithProducerME:(MEOutput*)arOutput
@@ -951,7 +1007,17 @@ end:
         arOutputSetting[(__bridge NSString*)kCVPixelBufferPixelFormatTypeKey] = @(kCVPixelFormatType_422YpCbCr8);
         AVAssetReaderOutput* arOutput = [AVAssetReaderTrackOutput assetReaderTrackOutputWithTrack:track
                                                                                    outputSettings:arOutputSetting];
-        [ar addOutput:arOutput];
+        __block BOOL arOK = FALSE;
+        dispatch_sync(self.processQueue, ^{
+            arOK = [ar canAddOutput:arOutput];
+        });
+        if (!arOK) {
+            SecureErrorLogf(@"Skipping video track(%d) - reader output not supported", track.trackID);
+            continue;
+        }
+        dispatch_sync(self.processQueue, ^{
+            [ar addOutput:arOutput];
+        });
         
         // source to
         MEInput* meInput = [MEInput inputWithManager:mgr];
@@ -978,7 +1044,17 @@ end:
         AVAssetWriterInput* awInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo
                                                                          outputSettings:awInputSetting];
         awInput.mediaTimeScale = track.naturalTimeScale;
-        [aw addInput:awInput];
+        __block BOOL awOK = FALSE;
+        dispatch_sync(self.processQueue, ^{
+            awOK = [aw canAddInput:awInput];
+        });
+        if (!awOK) {
+            SecureErrorLogf(@"Skipping video track(%d) - writer input not supported", track.trackID);
+            continue;
+        }
+        dispatch_sync(self.processQueue, ^{
+            [aw addInput:awInput];
+        });
         
         // destination channel
         SBChannel* sbcMEOutput = [SBChannel sbChannelWithProducerME:(MEOutput*)meOutput

--- a/movencoder2/METranscoder.m
+++ b/movencoder2/METranscoder.m
@@ -178,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
     AVAssetReader* assetReader = [[AVAssetReader alloc] initWithAsset:self.inMovie
                                                                 error:&error];
     if (!assetReader) {
-        NSLog(@"[METranscoder] ERROR: Failed to init AVAssetReader");
+        SecureErrorLog(@"[METranscoder] ERROR: Failed to init AVAssetReader");
         if (error)
             self.finalError = error;
         return FALSE;
@@ -190,7 +190,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                            fileType:AVFileTypeQuickTimeMovie
                                                               error:&error];
     if (!assetWriter) {
-        NSLog(@"[METranscoder] ERROR: Failed to init AVAssetWriter");
+        SecureErrorLog(@"[METranscoder] ERROR: Failed to init AVAssetWriter");
         if (error)
             self.finalError = error;
         return FALSE;
@@ -377,7 +377,7 @@ NS_ASSUME_NONNULL_BEGIN
         goto end;
     }
     
-    NSLog(@"[METranscoder] Export session started.");
+    SecureLog(@"[METranscoder] Export session started.");
     
     aw = self.assetWriter;
     ar = self.assetReader;
@@ -483,9 +483,9 @@ NS_ASSUME_NONNULL_BEGIN
 end:
     self.writerIsBusy = FALSE;
     if (self.finalSuccess) {
-        NSLog(@"[METranscoder] Export session completed.");
+        SecureLog(@"[METranscoder] Export session completed.");
     } else if (self.cancelled) {
-        NSLog(@"[METranscoder] Export session cancelled.");
+        SecureLog(@"[METranscoder] Export session cancelled.");
     } else {
         if (!self.finalError) {
             NSError* err = nil;
@@ -498,12 +498,12 @@ end:
         if (error) {
             *error = self.finalError;
         }
-        NSLog(@"[METranscoder] ERROR: Export session failed. Error details: %@", sanitizeLogString([self.finalError description]));
+        SecureErrorLogf(@"[METranscoder] ERROR: Export session failed. Error details: %@", [self.finalError description]);
     }
     
     //
     self.timeStamp1 = CFAbsoluteTimeGetCurrent();
-    NSLog(@"[METranscoder] elapsed: %.2f sec", self.timeElapsed);
+    SecureLogf(@"[METranscoder] elapsed: %.2f sec", self.timeElapsed);
 
     return self.finalSuccess;
 }

--- a/movencoder2/METranscoder.m
+++ b/movencoder2/METranscoder.m
@@ -131,9 +131,9 @@ NS_ASSUME_NONNULL_BEGIN
             
             // Try to create a temporary file to test write access
             NSError* error = nil;
-            BOOL success = [@"test" writeToFile:tempPath 
-                                     atomically:NO 
-                                       encoding:NSUTF8StringEncoding 
+            BOOL success = [@"test" writeToFile:tempPath
+                                     atomically:NO
+                                       encoding:NSUTF8StringEncoding
                                       error:&error];
         
             if (success) {

--- a/movencoder2/SBChannel.m
+++ b/movencoder2/SBChannel.m
@@ -29,6 +29,7 @@
 #import "MEInput.h"
 #import "MEOutput.h"
 #import "MEManager.h"
+#import "MESecureLogging.h"
 
 /* =================================================================================== */
 // MARK: -
@@ -118,7 +119,7 @@ void dumpTiming(CMSampleBufferRef sb, NSString* typeString, NSString* tag, int c
     int32_t ptsScale = pts.timescale;
     float dtime = CMTimeGetSeconds(dur);
     float ptime = CMTimeGetSeconds(pts);
-    NSLog(@"%@ [%@] : %lld/%d(%.2f), %lld/%d(%.2f) %d",
+    SecureLogf(@"%@ [%@] : %lld/%d(%.2f), %lld/%d(%.2f) %d",
           typeString, tag, dtsValue, dtsScale, dtime, ptsValue, ptsScale, ptime, count);
 }
 

--- a/movencoder2/monitorUtil.h
+++ b/movencoder2/monitorUtil.h
@@ -35,7 +35,7 @@ typedef void (^monitor_block_t)(void);
 typedef void (^cancel_block_t)(void);
 
 void startMonitor(monitor_block_t mon, cancel_block_t can);
-void finishMonitor(int code) ;
+void finishMonitor(int code, NSString* _Nullable msg, NSString* _Nullable errMsg);
 int lastSignal(void);
 
 NS_ASSUME_NONNULL_END

--- a/movencoder2/monitorUtil.m
+++ b/movencoder2/monitorUtil.m
@@ -26,6 +26,7 @@
 
 #import "MECommon.h"
 #import "monitorUtil.h"
+#import "MESecureLogging.h"
 
 /* =================================================================================== */
 // MARK: -
@@ -90,7 +91,7 @@ static void cancelAndExit(int code, cancel_block_t  _Nonnull can) {
     
     // Actual cleanup/exit operation should be performed in monitor_block_t
     
-    NSLog(@"Force quit"); // Hangup condition detected
+    SecureLog(@"Force quit"); // Hangup condition detected
     exitAsync(code, timerSource());
 }
 
@@ -128,12 +129,12 @@ void startMonitor(monitor_block_t mon, cancel_block_t can) {
     // install GCD based signal handler
     signalSrcInstaller(SIGINT, ^{
         printf("\n");
-        NSLog(@"SIGINT detected");
+        SecureLog(@"SIGINT detected");
         cancelAndExit(SIGINT, can); // never returns
     });
     signalSrcInstaller(SIGTERM, ^{
         printf("\n");
-        NSLog(@"SIGTERM detected");
+        SecureLog(@"SIGTERM detected");
         cancelAndExit(SIGTERM, can); // never returns
     });
 

--- a/movencoder2/monitorUtil.m
+++ b/movencoder2/monitorUtil.m
@@ -95,6 +95,13 @@ static void cancelAndExit(int code, cancel_block_t  _Nonnull can) {
     exitAsync(code, timerSource());
 }
 
+static void cancelAllHandlers(dispatch_source_t _Nullable srcToCancel) {
+    if (srcToCancel) {
+        dispatch_source_set_event_handler(srcToCancel, nil);
+        dispatch_source_set_cancel_handler(srcToCancel, nil);
+    }
+}
+
 static dispatch_source_t timerSrcInstaller(dispatch_block_t handler, dispatch_block_t completion) {
     dispatch_time_t start = dispatch_time(DISPATCH_TIME_NOW, hbInterval);
     dispatch_source_t src = timerSource();
@@ -111,6 +118,13 @@ static dispatch_source_t signalSrcInstaller(int code, dispatch_block_t handler) 
     dispatch_source_set_event_handler(src, handler);
     dispatch_resume(src);
     return src;
+}
+
+static void logInfoOrError(NSString * _Nullable msg, NSString * _Nullable errMsg) {
+    if (msg)
+        SecureLogf(@"%@", msg);
+    if (errMsg)
+        SecureErrorLogf(@"%@", errMsg);
 }
 
 /* =================================================================================== */
@@ -142,7 +156,9 @@ void startMonitor(monitor_block_t mon, cancel_block_t can) {
     dispatch_main();
 }
 
-void finishMonitor(int code) {
+void finishMonitor(int code, NSString* _Nullable msg, NSString* _Nullable errMsg) {
+    cancelAllHandlers(timerSource());
+    logInfoOrError(msg, errMsg);
     exitAsync(code, timerSource());
 }
 

--- a/movencoder2/parseUtil.m
+++ b/movencoder2/parseUtil.m
@@ -73,7 +73,7 @@ NSNumber* parseInteger(NSString* val) {
     }
 
 error:
-    NSLog(@"ERROR: '%@' is not a valid integer value (optionally with K/M/G/T suffix, 1000-base)", sanitizeLogString(val));
+    SecureErrorLogf(@"'%@' is not a valid integer value (optionally with K/M/G/T suffix, 1000-base)", val);
     return nil;
     }
 }
@@ -110,7 +110,7 @@ NSNumber* parseDouble(NSString* val) {
         }
 
 error:
-        NSLog(@"ERROR: '%@' is not a valid double value (optionally with K/M/G/T suffix, 1000-base)", sanitizeLogString(val));
+        SecureErrorLogf(@"'%@' is not a valid double value (optionally with K/M/G/T suffix, 1000-base)", val);
         return nil;
     }
 }
@@ -137,7 +137,7 @@ NSValue* parseSize(NSString* val) {
     }
     
 error:
-    NSLog(@"ERROR: %@ : not Size", sanitizeLogString(val));
+    SecureErrorLogf(@"%@ : not Size", val);
     return nil;
 }
 
@@ -166,7 +166,7 @@ NSValue* parseRect(NSString* val) {
     }
     
 error:
-    NSLog(@"ERROR: %@ : not Rect", sanitizeLogString(val));
+    SecureErrorLogf(@"%@ : not Rect", val);
     return nil;
 }
 
@@ -214,7 +214,7 @@ NSValue* parseTime(NSString* val) {
     }
     
 error:
-    NSLog(@"ERROR: %@ : not Time", sanitizeLogString(val));
+    SecureErrorLogf(@"Failed to parse time value: %@", val);
     return nil;
 }
 
@@ -234,7 +234,7 @@ NSNumber* parseBool(NSString* val) {
     if (isNo) return @NO;
     
 error:
-    NSLog(@"ERROR: '%@' is not a valid boolean value (expected: YES/NO, TRUE/FALSE, ON/OFF, 1/0)", sanitizeLogString(val));
+    SecureErrorLogf(@"'%@' is not a valid boolean value (expected: YES/NO, TRUE/FALSE, ON/OFF, 1/0)", val);
     return nil;
 }
 
@@ -265,14 +265,14 @@ NSDictionary* parseCodecOptions(NSString* val) {
     }
     
     if (skipped.count) {
-        NSLog(@"ERROR: Invalid codec options format in '%@', skipped options: %@", sanitizeLogString(val), sanitizeLogString([skipped description]));
+        SecureErrorLogf(@"Invalid codec options format in '%@', skipped options: %@", val, [skipped description]);
     }
     
     if (options.allKeys.count) {
         return [options copy];
     }
     
-    NSLog(@"ERROR: '%@' contains no valid codec options (expected format: key1=value1:key2=value2)", sanitizeLogString(val));
+    SecureErrorLogf(@"'%@' contains no valid codec options (expected format: key1=value1:key2=value2)", val);
     return nil;
 }
 
@@ -304,7 +304,7 @@ NSNumber* parseLayoutTag(NSString* val) {
     NSNumber* num = parseInteger(val);
     if (num != nil) return num;
     
-    NSLog(@"ERROR: %@ : not valid AAC layout name or integer", sanitizeLogString(val));
+    SecureErrorLogf(@"%@ : not valid AAC layout name or integer", val);
     return nil;
 }
 

--- a/movencoder2/parseUtil.m
+++ b/movencoder2/parseUtil.m
@@ -39,43 +39,55 @@ NSNumber* parseInteger(NSString* val) {
     @autoreleasepool {
         // Trim whitespace and newlines from input
         val = [val stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-        
+
+        if (val.length == 0) goto error;
+
         NSScanner *ns = [NSScanner scannerWithString:val];
         long long theValue = 0;
-        if ([ns scanLongLong:&theValue]) {
-            // parse metric prefix - accept only a single-letter suffix (K/M/G/T)
-            if (!ns.atEnd) {
-                NSString* suffix = nil;
-                NSCharacterSet* cSet = [NSCharacterSet letterCharacterSet];
-                if ([ns scanCharactersFromSet:cSet intoString:&suffix] && ns.atEnd) {
-                    if (suffix.length != 1) goto error; // reject multi-letter suffix like "MB"
+        if (![ns scanLongLong:&theValue]) {
+            goto error;
+        }
+
+        // If there are remaining characters, attempt to parse a single-letter metric suffix
+        if (!ns.atEnd) {
+            NSString *suffix = nil;
+            NSCharacterSet *letters = [NSCharacterSet letterCharacterSet];
+            if ([ns scanCharactersFromSet:letters intoString:&suffix] && ns.atEnd) {
+                if (suffix.length != 1) goto error; // reject multi-letter suffix like "MB"
                 unichar ch = [suffix characterAtIndex:0];
-                long long multiplier = 1;
+                unsigned long long multiplier = 1ULL;
                 switch (toupper((int)ch)) {
-                    case 'T': multiplier = 1000LL * 1000LL * 1000LL * 1000LL; break;
-                    case 'G': multiplier = 1000LL * 1000LL * 1000LL; break;
-                    case 'M': multiplier = 1000LL * 1000LL; break;
-                    case 'K': multiplier = 1000LL; break;
+                    case 'T': multiplier = 1000ULL * 1000ULL * 1000ULL * 1000ULL; break;
+                    case 'G': multiplier = 1000ULL * 1000ULL * 1000ULL; break;
+                    case 'M': multiplier = 1000ULL * 1000ULL; break;
+                    case 'K': multiplier = 1000ULL; break;
                     default: goto error;
                 }
-                // overflow check before multiplication
-                if (theValue > 0 && (unsigned long long)theValue > ULLONG_MAX / (unsigned long long)multiplier) goto error;
-                if (theValue < 0) {
-                    // Handle INT64_MIN edge case: -INT64_MIN causes undefined behavior due to overflow
-                    if (theValue == INT64_MIN) goto error;
-                    if ((unsigned long long)(-theValue) > ULLONG_MAX / (unsigned long long)multiplier) goto error;
+
+                // Overflow checks
+                if (theValue > 0) {
+                    if ((unsigned long long)theValue > ULLONG_MAX / multiplier) goto error;
+                } else if (theValue < 0) {
+                    // handle negative values safely
+                    if (theValue == LLONG_MIN) goto error;
+                    if ((unsigned long long)(-theValue) > ULLONG_MAX / multiplier) goto error;
                 }
-                long long result = theValue * multiplier;
+
+                long long result = (long long)((unsigned long long)llabs(theValue) * multiplier);
+                if (theValue < 0) result = -result;
                 return [NSNumber numberWithLongLong:result];
+            } else {
+                // Unexpected trailing characters
+                goto error;
             }
         }
+
         return [NSNumber numberWithLongLong:theValue];
     }
 
 error:
     SecureErrorLogf(@"'%@' is not a valid integer value (optionally with K/M/G/T suffix, 1000-base)", val);
     return nil;
-    }
 }
 
 NSNumber* parseDouble(NSString* val) {
@@ -171,25 +183,36 @@ error:
 }
 
 NSValue* parseTime(NSString* val) {
-    // Try to interpret as a rational number first
-    //   "30000:1001" -> CMTimeMake(30000, 1001) (frames per second)
     NSValue* _Nullable (^toTime)(NSString*, NSString*) = ^NSValue* (NSString* val, NSString* delimiter) {
-         NSValue* outVal = nil;
-         NSArray* array = [val componentsSeparatedByString:delimiter];
-         if (array.count == 2) {
-             NSNumber* numerator = parseInteger(array[0]);
-             NSNumber* denominator = parseInteger(array[1]);
-             if (numerator && denominator) {
-                 long long numeratorLL = [numerator longLongValue];
-                 long long denominatorLL = [denominator longLongValue];
-                 if (denominatorLL <= 0 || numeratorLL <= 0) return nil;
-                 if (denominatorLL > INT32_MAX) return nil;
-                 CMTime time = CMTimeMake((int64_t)numeratorLL, (int32_t)denominatorLL);
-                 outVal = [NSValue valueWithCMTime:time];
-             }
-         }
-         return outVal;
-     };
+        NSValue* outVal = nil;
+        NSArray* array = [val componentsSeparatedByString:delimiter];
+        if (array.count == 2) {
+            NSNumber* numerator = parseInteger(array[0]);
+            NSNumber* denominator = parseInteger(array[1]);
+            if (numerator && denominator) {
+                long long numeratorLL = [numerator longLongValue];
+                long long denominatorLL = [denominator longLongValue];
+                
+                // Strengthen denominator validation
+                if (denominatorLL <= 0) {
+                    SecureErrorLogf(@"Invalid denominator (must be positive): %lld", denominatorLL);
+                    return nil;
+                }
+                if (denominatorLL > INT32_MAX) {
+                    SecureErrorLogf(@"Denominator too large (max %d): %lld", INT32_MAX, denominatorLL);
+                    return nil;
+                }
+                if (numeratorLL <= 0) {
+                    SecureErrorLogf(@"Invalid numerator (must be positive): %lld", numeratorLL);
+                    return nil;
+                }
+                
+                CMTime time = CMTimeMake((int64_t)numeratorLL, (int32_t)denominatorLL);
+                outVal = [NSValue valueWithCMTime:time];
+            }
+        }
+        return outVal;
+    };
     
     NSValue* outValue = nil;
     for (NSString* delimiter in @[@":",@"/",@"x",@","]) {
@@ -197,17 +220,42 @@ NSValue* parseTime(NSString* val) {
         if (outValue) return outValue;
     }
     
-    // Interpret as a plain floating point value (assumed as frame rate)
-    //   "29.97" -> CMTimeMake(90000, 3003) (frames per second)
-    // NOTE: Timebase 90000 is used as project-wide timescale
+    // Improved conversion from floating-point FPS to CMTime
     NSNumber* numValue = parseDouble(val);
     if (numValue != nil) {
         double fps = [numValue doubleValue];
         if (!(fps > 0.0 && isfinite(fps))) {
+            SecureErrorLogf(@"Invalid FPS value: %f", fps);
             goto error;
         }
-        int64_t numerator = 90000;  // Use timebase 90000 as project-wide timescale
-        int32_t denominator = (int32_t)floor((double)numerator / fps);
+        
+        // Validate FPS range
+        if (fps > 1000.0) {
+            SecureErrorLogf(@"FPS too high (max 1000): %f", fps);
+            goto error;
+        }
+        if (fps < 0.001) {
+            SecureErrorLogf(@"FPS too low (min 0.001): %f", fps);
+            goto error;
+        }
+        
+        int64_t numerator = 90000;  // Use timebase 90000
+        double rawDenominator = (double)numerator / fps;
+        
+        // Check denominator does not exceed INT32_MAX
+        if (rawDenominator > INT32_MAX) {
+            SecureErrorLogf(@"Calculated denominator too large for FPS %f: %f", fps, rawDenominator);
+            goto error;
+        }
+        
+        int32_t denominator = (int32_t)floor(rawDenominator);
+        
+        // Check denominator is not zero
+        if (denominator <= 0) {
+            SecureErrorLogf(@"Calculated denominator invalid for FPS %f: %d", fps, denominator);
+            goto error;
+        }
+        
         CMTime timeValue = CMTimeMake(numerator, denominator);
         outValue = [NSValue valueWithCMTime:timeValue];
         if (outValue) return outValue;


### PR DESCRIPTION
This pull request updates the logging system throughout the `movencoder2` module to use secure logging methods instead of `NSLog`. The main goal is to improve logging security and consistency by replacing all standard log calls with their secure equivalents, grouped by log level (error, debug, info). The changes also ensure that the secure logging header is imported where needed.

**Secure Logging Integration**

* All instances of `NSLog` in `MEManager.m`, `MEAudioConverter.m`, and related files have been replaced with secure logging functions such as `SecureErrorLogf`, `SecureLogf`, and `SecureDebugLogf` to enhance security and standardize logging output. [[1]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL317-R318) [[2]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL328-R341) [[3]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL351-R384) [[4]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL395-R396) [[5]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL407-R414) [[6]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL444-R445) [[7]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL479-R480) [[8]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL509-R510) [[9]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL518-R519) [[10]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL581-R582) [[11]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL599-R600) [[12]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL609-R610) [[13]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL624-R637) [[14]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL666-R690) [[15]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL698-R699) [[16]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL710-R711) [[17]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL727-R736) [[18]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL752-R759) [[19]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL794-R800) [[20]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL811-R812) [[21]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebL839-R840) [[22]](diffhunk://#diff-ff4be5a278bedeb29d81bcefa5cbd1a537f78dca2c765c02f01b7307b69794f2L483-R484) [[23]](diffhunk://#diff-ff4be5a278bedeb29d81bcefa5cbd1a537f78dca2c765c02f01b7307b69794f2L554-R555) [[24]](diffhunk://#diff-ff4be5a278bedeb29d81bcefa5cbd1a537f78dca2c765c02f01b7307b69794f2L719-R720)

* The `ALog` macro in `MECommon.h` is updated to use `SecureDebugLogf` instead of `NSLog`.

**Header and Dependency Updates**

* The `MESecureLogging.h` header is now imported in all relevant files (`MECommon.h`, `MEManager.m`, `MEAudioConverter.m`) to provide access to the new secure logging macros and functions. [[1]](diffhunk://#diff-3648c99afe9419a5670d5f06c37ca0ddbdc68ab4b983fa01a8e45d48e6f39ed3R32-R39) [[2]](diffhunk://#diff-ca39610dcf4c9deeea2945e70e586d37ca35e7d35ec52d96d9cc039f9e4339ebR30) [[3]](diffhunk://#diff-ff4be5a278bedeb29d81bcefa5cbd1a537f78dca2c765c02f01b7307b69794f2R29)

These changes ensure that all logging is handled securely and consistently across the codebase.