### PR TITLE
fix: resolve commandline tool compilation failure; update to Xcode 26.4 RC

### DIFF
--- a/movencoder2.xcodeproj/project.pbxproj
+++ b/movencoder2.xcodeproj/project.pbxproj
@@ -60,9 +60,6 @@
 
 /* Begin PBXFileReference section */
 		161907892884E28B001BFA7E /* HowToBuildLibs.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = HowToBuildLibs.md; sourceTree = "<group>"; };
-		163227632F6EABC70072CCC1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		163227672F6EAC070072CCC1 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
-		163227682F6EAC070072CCC1 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		1654A0C826DC75D500E7DBB8 /* liblzma.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = liblzma.dylib; path = ../../../../../opt/local/lib/liblzma.dylib; sourceTree = "<group>"; };
 		1654A0C926DC75D500E7DBB8 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = ../../../../../opt/local/lib/libz.dylib; sourceTree = "<group>"; };
 		1654A0CA26DC75D500E7DBB8 /* libbz2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.dylib; path = ../../../../../opt/local/lib/libbz2.dylib; sourceTree = "<group>"; };
@@ -81,7 +78,6 @@
 		16A9573A22C05AED008868AF /* COPYING.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = COPYING.txt; sourceTree = "<group>"; };
 		16A9573B22C05AED008868AF /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		16B81251218D701000E24173 /* movencoder2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = movencoder2; sourceTree = BUILT_PRODUCTS_DIR; };
-		16C1DAF32E87F0A000DD415F /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = System/Library/Frameworks/XCTest.framework; sourceTree = SDKROOT; };
 		16C1DAF62E87F12000DD415F /* movencoder2Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = movencoder2Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		16DF75652F6F686F00EA55E0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		240B87D07B35999E9BDDD7D0 /* MovEncoder2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MovEncoder2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -316,9 +312,6 @@
 			isa = PBXGroup;
 			children = (
 				16DF75652F6F686F00EA55E0 /* XCTest.framework */,
-				163227682F6EAC070072CCC1 /* CoreAudio.framework */,
-				163227672F6EAC070072CCC1 /* CoreVideo.framework */,
-				163227632F6EABC70072CCC1 /* Foundation.framework */,
 				1654A0CE26DC763C00E7DBB8 /* dylib at usr-local-lib */,
 				1654A0C726DC75C000E7DBB8 /* dylib at opt-local-lib */,
 				16741CE721A92550000EEC78 /* CoreMedia.framework */,
@@ -338,7 +331,6 @@
 				161DAF562F3B6D65002777AA /* movencoder2Tests */,
 				16B81252218D701000E24173 /* Products */,
 				16AD45BF21965FB500A0BB95 /* Frameworks */,
-				16C1DAFC2E87F21B00DD415F /* Recovered References */,
 				A50EB28E4A257BA3C5CDDEDE /* MovEncoder2Framework */,
 			);
 			sourceTree = "<group>";
@@ -351,14 +343,6 @@
 				240B87D07B35999E9BDDD7D0 /* MovEncoder2.framework */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		16C1DAFC2E87F21B00DD415F /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				16C1DAF32E87F0A000DD415F /* XCTest.framework */,
-			);
-			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		A50EB28E4A257BA3C5CDDEDE /* MovEncoder2Framework */ = {

--- a/movencoder2.xcodeproj/project.pbxproj
+++ b/movencoder2.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		1654A0E026DC769000E7DBB8 /* libswresample.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D626DC768F00E7DBB8 /* libswresample.dylib */; };
 		1654A0E126DC769000E7DBB8 /* libx265.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D726DC768F00E7DBB8 /* libx265.dylib */; };
 		1654A0E226DC769000E7DBB8 /* libavcodec.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D826DC768F00E7DBB8 /* libavcodec.dylib */; };
-		16C1DAF42E87F0A000DD415F /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16C1DAF32E87F0A000DD415F /* XCTest.framework */; };
 		16C1DAFD2E87F28B00DD415F /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0CA26DC75D500E7DBB8 /* libbz2.dylib */; };
 		16C1DAFE2E87F29200DD415F /* liblzma.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0C826DC75D500E7DBB8 /* liblzma.dylib */; };
 		16C1DAFF2E87F29800DD415F /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0C926DC75D500E7DBB8 /* libz.dylib */; };
@@ -35,16 +34,14 @@
 		16C1DB062E87F2C600DD415F /* libavfilter.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D126DC768F00E7DBB8 /* libavfilter.dylib */; };
 		16C1DB072E87F2CC00DD415F /* libavdevice.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D426DC768F00E7DBB8 /* libavdevice.dylib */; };
 		16C1DB082E87F2D200DD415F /* libavcodec.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D826DC768F00E7DBB8 /* libavcodec.dylib */; };
+		16DF75662F6F686F00EA55E0 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16DF75652F6F686F00EA55E0 /* XCTest.framework */; };
 		1D11CDEAA37208A00F416DEF /* libavcodec.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D826DC768F00E7DBB8 /* libavcodec.dylib */; };
 		4A9287D6166428C1DB3F3945 /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0CA26DC75D500E7DBB8 /* libbz2.dylib */; };
 		5A21ABF6702D4913705C3748 /* libavfilter.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D126DC768F00E7DBB8 /* libavfilter.dylib */; };
-		69AF04979304B7A6C8CE98D9 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16741CE721A92550000EEC78 /* CoreMedia.framework */; };
-		6F9EF8D740509057050870E8 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 166902585CAFD658422CF0F8 /* Cocoa.framework */; };
 		85CE3B3CFE2A53FA1E25F99B /* libx265.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D726DC768F00E7DBB8 /* libx265.dylib */; };
 		BB36A6D4000AA00152243FE6 /* liblzma.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0C826DC75D500E7DBB8 /* liblzma.dylib */; };
 		C67550F6C4471657E6B67C5D /* libavformat.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D326DC768F00E7DBB8 /* libavformat.dylib */; };
 		C76FF6E92A6AD27413CBDEDF /* libx264.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D026DC768F00E7DBB8 /* libx264.dylib */; };
-		CBF8E46DE3E75C3B7F0BD145 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16741CE521A924FB000EEC78 /* AVFoundation.framework */; };
 		DE577915143D75A96A0DE43E /* libavdevice.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D426DC768F00E7DBB8 /* libavdevice.dylib */; };
 		E4F9A06F257156BF211086FE /* libavutil.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1654A0D526DC768F00E7DBB8 /* libavutil.dylib */; };
 /* End PBXBuildFile section */
@@ -63,6 +60,9 @@
 
 /* Begin PBXFileReference section */
 		161907892884E28B001BFA7E /* HowToBuildLibs.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = HowToBuildLibs.md; sourceTree = "<group>"; };
+		163227632F6EABC70072CCC1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		163227672F6EAC070072CCC1 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
+		163227682F6EAC070072CCC1 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		1654A0C826DC75D500E7DBB8 /* liblzma.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = liblzma.dylib; path = ../../../../../opt/local/lib/liblzma.dylib; sourceTree = "<group>"; };
 		1654A0C926DC75D500E7DBB8 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = ../../../../../opt/local/lib/libz.dylib; sourceTree = "<group>"; };
 		1654A0CA26DC75D500E7DBB8 /* libbz2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.dylib; path = ../../../../../opt/local/lib/libbz2.dylib; sourceTree = "<group>"; };
@@ -83,6 +83,7 @@
 		16B81251218D701000E24173 /* movencoder2 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = movencoder2; sourceTree = BUILT_PRODUCTS_DIR; };
 		16C1DAF32E87F0A000DD415F /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = System/Library/Frameworks/XCTest.framework; sourceTree = SDKROOT; };
 		16C1DAF62E87F12000DD415F /* movencoder2Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = movencoder2Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		16DF75652F6F686F00EA55E0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		240B87D07B35999E9BDDD7D0 /* MovEncoder2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MovEncoder2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		96C92E42B9EE5C37768656ED /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -248,12 +249,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				16C1DB052E87F2C000DD415F /* libavformat.dylib in Frameworks */,
-				16C1DAF42E87F0A000DD415F /* XCTest.framework in Frameworks */,
 				16C1DB042E87F2B700DD415F /* libavutil.dylib in Frameworks */,
 				16C1DAFF2E87F29800DD415F /* libz.dylib in Frameworks */,
 				16C1DAFE2E87F29200DD415F /* liblzma.dylib in Frameworks */,
 				16C1DB072E87F2CC00DD415F /* libavdevice.dylib in Frameworks */,
 				16C1DB062E87F2C600DD415F /* libavfilter.dylib in Frameworks */,
+				16DF75662F6F686F00EA55E0 /* XCTest.framework in Frameworks */,
 				16C1DAFD2E87F28B00DD415F /* libbz2.dylib in Frameworks */,
 				16C1DB012E87F2A500DD415F /* libx264.dylib in Frameworks */,
 				16C1DB082E87F2D200DD415F /* libavcodec.dylib in Frameworks */,
@@ -267,9 +268,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6F9EF8D740509057050870E8 /* Cocoa.framework in Frameworks */,
-				CBF8E46DE3E75C3B7F0BD145 /* AVFoundation.framework in Frameworks */,
-				69AF04979304B7A6C8CE98D9 /* CoreMedia.framework in Frameworks */,
 				E4F9A06F257156BF211086FE /* libavutil.dylib in Frameworks */,
 				4A9287D6166428C1DB3F3945 /* libbz2.dylib in Frameworks */,
 				C76FF6E92A6AD27413CBDEDF /* libx264.dylib in Frameworks */,
@@ -317,6 +315,10 @@
 		16AD45BF21965FB500A0BB95 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				16DF75652F6F686F00EA55E0 /* XCTest.framework */,
+				163227682F6EAC070072CCC1 /* CoreAudio.framework */,
+				163227672F6EAC070072CCC1 /* CoreVideo.framework */,
+				163227632F6EABC70072CCC1 /* Foundation.framework */,
 				1654A0CE26DC763C00E7DBB8 /* dylib at usr-local-lib */,
 				1654A0C726DC75C000E7DBB8 /* dylib at opt-local-lib */,
 				16741CE721A92550000EEC78 /* CoreMedia.framework */,
@@ -452,7 +454,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 2620;
+				LastUpgradeCheck = 2640;
 				ORGANIZATIONNAME = MyCometG3;
 				TargetAttributes = {
 					16B81250218D701000E24173 = {
@@ -522,6 +524,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -584,6 +587,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -762,6 +766,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				EXCLUDED_ARCHS = "";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -780,7 +785,6 @@
 					/usr/local/lib,
 					/opt/local/lib,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				MODULEMAP_FILE = "";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
@@ -807,6 +811,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				EXCLUDED_ARCHS = "";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -825,7 +830,6 @@
 					/usr/local/lib,
 					/opt/local/lib,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				MODULEMAP_FILE = "";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";

--- a/movencoder2.xcodeproj/xcshareddata/xcschemes/MovEncoder2Framework.xcscheme
+++ b/movencoder2.xcodeproj/xcshareddata/xcschemes/MovEncoder2Framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/movencoder2.xcodeproj/xcshareddata/xcschemes/movencoder2.xcscheme
+++ b/movencoder2.xcodeproj/xcshareddata/xcschemes/movencoder2.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/movencoder2.xcodeproj/xcshareddata/xcschemes/movencoder2Tests.xcscheme
+++ b/movencoder2.xcodeproj/xcshareddata/xcschemes/movencoder2Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/movencoder2/Core/MEAudioConverter.h
+++ b/movencoder2/Core/MEAudioConverter.h
@@ -85,7 +85,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Volume/gain adjustment in dB. Set to 0.0 for no adjustment.
- Valid range: -10.0 to +10.0 dB. Values outside this range will be automatically clamped.
+ Valid range: -10.0 to +10.0 dB. Finite values outside this range will be automatically clamped.
+ Non-finite values (NaN or ±Inf) are treated as invalid and reset to 0.0 dB (no adjustment).
  */
 @property (nonatomic) double volumeDb;
 

--- a/movencoder2/Core/MEAudioConverter.h
+++ b/movencoder2/Core/MEAudioConverter.h
@@ -38,6 +38,9 @@ typedef void (^RequestHandler)(void);
 
 NS_ASSUME_NONNULL_END
 
+#define MEAudioConverterMinVolumeDB (-10.0)
+#define MEAudioConverterMaxVolumeDB (10.0)
+
 /* =================================================================================== */
 // MARK: -
 /* =================================================================================== */
@@ -82,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Volume/gain adjustment in dB. Set to 0.0 for no adjustment.
- Valid range: -10.0 to +10.0 dB
+ Valid range: -10.0 to +10.0 dB. Values outside this range will be automatically clamped.
  */
 @property (nonatomic) double volumeDb;
 

--- a/movencoder2/Core/MEAudioConverter.h
+++ b/movencoder2/Core/MEAudioConverter.h
@@ -38,8 +38,8 @@ typedef void (^RequestHandler)(void);
 
 NS_ASSUME_NONNULL_END
 
-#define MEAudioConverterMinVolumeDB (-10.0)
-#define MEAudioConverterMaxVolumeDB (10.0)
+static const double MEAudioConverterMinVolumeDB = -10.0;
+static const double MEAudioConverterMaxVolumeDB = 10.0;
 
 /* =================================================================================== */
 // MARK: -

--- a/movencoder2/Core/MEAudioConverter.m
+++ b/movencoder2/Core/MEAudioConverter.m
@@ -16,6 +16,9 @@
 #import "MESecureLogging.h"
 #include <unistd.h>
 
+static const void *kMEInputQueueKey = &kMEInputQueueKey;
+static const void *kMEOutputQueueKey = &kMEOutputQueueKey;
+
 #define DEFAULT_MAX_INPUT_BUFFERS (10)
 #define OUTPUT_POLL_TIMEOUT_MS (50)
 
@@ -69,6 +72,9 @@ NS_ASSUME_NONNULL_BEGIN
         _inputQueue = dispatch_queue_create("MEAudioConverter.input", DISPATCH_QUEUE_SERIAL);
         _outputQueue = dispatch_queue_create("MEAudioConverter.output", DISPATCH_QUEUE_SERIAL);
         
+        dispatch_queue_set_specific(_inputQueue, kMEInputQueueKey, (void *)kMEInputQueueKey, NULL);
+        dispatch_queue_set_specific(_outputQueue, kMEOutputQueueKey, (void *)kMEOutputQueueKey, NULL);
+        
         _inputBufferQueue = [NSMutableArray array];
         _outputBufferQueue = [NSMutableArray array];
         
@@ -106,28 +112,64 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)cleanup
 {
-    // Use dispatch_async for cleanup to prevent deadlock between input and output queues
-    dispatch_async(_inputQueue, ^{
-        for (NSValue* value in self->_inputBufferQueue) {
-            CMSampleBufferRef sampleBuffer = (CMSampleBufferRef)[value pointerValue];
-            if (sampleBuffer) {
-                CFRelease(sampleBuffer);
-            }
-        }
+    // Determine if we're currently executing on the specific queues
+    BOOL onInputQueue = (dispatch_get_specific(kMEInputQueueKey) != NULL);
+    BOOL onOutputQueue = (dispatch_get_specific(kMEOutputQueueKey) != NULL);
+
+    // Snapshots to release outside of the queues
+    __block NSArray<NSValue *> *inputValues = nil;
+    __block NSArray<NSValue *> *outputValues = nil;
+
+    // Drain input queue synchronously (or inline if already on it)
+    if (onInputQueue) {
+        inputValues = [self->_inputBufferQueue copy] ?: @[];
         [self->_inputBufferQueue removeAllObjects];
-    });
-    
-    dispatch_async(_outputQueue, ^{
-        for (NSValue* value in self->_outputBufferQueue) {
-            CMSampleBufferRef sampleBuffer = (CMSampleBufferRef)[value pointerValue];
-            if (sampleBuffer) {
-                CFRelease(sampleBuffer);
-            }
-        }
+    } else if (_inputQueue) {
+        dispatch_sync(_inputQueue, ^{
+            inputValues = [self->_inputBufferQueue copy] ?: @[];
+            [self->_inputBufferQueue removeAllObjects];
+        });
+    } else {
+        inputValues = @[];
+    }
+
+    // Drain output queue synchronously (or inline if already on it)
+    if (onOutputQueue) {
+        outputValues = [self->_outputBufferQueue copy] ?: @[];
         [self->_outputBufferQueue removeAllObjects];
-    });
-    
-    [self.audioBufferListPool setLength:0];
+    } else if (_outputQueue) {
+        dispatch_sync(_outputQueue, ^{
+            outputValues = [self->_outputBufferQueue copy] ?: @[];
+            [self->_outputBufferQueue removeAllObjects];
+        });
+    } else {
+        outputValues = @[];
+    }
+
+    // Release outside of queues to avoid retaining self in async blocks
+    for (NSValue *value in inputValues) {
+        CMSampleBufferRef sampleBuffer = (CMSampleBufferRef)[value pointerValue];
+        if (sampleBuffer) {
+            CFRelease(sampleBuffer);
+        }
+    }
+    for (NSValue *value in outputValues) {
+        CMSampleBufferRef sampleBuffer = (CMSampleBufferRef)[value pointerValue];
+        if (sampleBuffer) {
+            CFRelease(sampleBuffer);
+        }
+    }
+
+    // Reset pooled storage synchronously on the input queue to avoid races
+    if (onInputQueue) {
+        [self.audioBufferListPool setLength:0];
+    } else if (_inputQueue) {
+        dispatch_sync(_inputQueue, ^{
+            [self.audioBufferListPool setLength:0];
+        });
+    } else {
+        [self.audioBufferListPool setLength:0];
+    }
 }
 
 - (AVMediaType)mediaType
@@ -407,3 +449,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+

--- a/movencoder2/Core/MEAudioConverter.m
+++ b/movencoder2/Core/MEAudioConverter.m
@@ -431,6 +431,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setVolumeDb:(double)volumeDb
 {
+    if (!isfinite(volumeDb)) {
+        _volumeDb = 0.0;
+        return;
+    }
     if (volumeDb < MEAudioConverterMinVolumeDB) {
         if (self.verbose) {
             SecureLogf(@"volumeDb clamped from %f to %f (minimum)", volumeDb, MEAudioConverterMinVolumeDB);

--- a/movencoder2/Core/MEAudioConverter.m
+++ b/movencoder2/Core/MEAudioConverter.m
@@ -16,6 +16,9 @@
 #import "MESecureLogging.h"
 #include <unistd.h>
 
+#define DEFAULT_MAX_INPUT_BUFFERS (10)
+#define OUTPUT_POLL_TIMEOUT_MS (50)
+
 /* =================================================================================== */
 // MARK: -
 /* =================================================================================== */
@@ -82,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.startTime = kCMTimeInvalid;
         self.endTime = kCMTimeInvalid;
         
-        self.maxInputBufferCount = 10;
+        self.maxInputBufferCount = DEFAULT_MAX_INPUT_BUFFERS;
         
         self.audioBufferListPool = [NSMutableData data];
     }
@@ -123,6 +126,8 @@ NS_ASSUME_NONNULL_BEGIN
         }
         [self->_outputBufferQueue removeAllObjects];
     });
+    
+    [self.audioBufferListPool setLength:0];
 }
 
 - (AVMediaType)mediaType
@@ -148,13 +153,9 @@ NS_ASSUME_NONNULL_BEGIN
     __block BOOL success = YES;
     dispatch_sync(_inputQueue, ^{
         // Ensure converter is available when formats are set
-        if (!self->_audioConverter && self.sourceFormat && self.destinationFormat) {
-            self->_audioConverter = [[AVAudioConverter alloc] initFromFormat:self.sourceFormat toFormat:self.destinationFormat];
-            if (!self->_audioConverter) {
-                self.failed = YES;
-                if (self.verbose) {
-                    SecureErrorLog(@"Failed to create AVAudioConverter");
-                }
+        if (!self->_audioConverter) {
+            [self ensureAudioConverter];
+            if (self.failed) {
                 success = NO;
                 return;
             }
@@ -166,7 +167,7 @@ NS_ASSUME_NONNULL_BEGIN
         [self->_inputBufferQueue addObject:value];
 
         // Trigger processing if converter is available
-        if (self->_audioConverter && self.sourceFormat && self.destinationFormat) {
+        if (self->_audioConverter) {
             [self processNextBuffer];
         }
     });
@@ -221,13 +222,9 @@ NS_ASSUME_NONNULL_BEGIN
         self->_inputRequestHandler = [block copy];
         
         // Initialize the audio converter if not already done
-        if (!self->_audioConverter && self.sourceFormat && self.destinationFormat) {
-            self->_audioConverter = [[AVAudioConverter alloc] initFromFormat:self.sourceFormat toFormat:self.destinationFormat];
-            if (!self->_audioConverter) {
-                self.failed = YES;
-                if (self.verbose) {
-                    SecureErrorLog(@"Failed to create AVAudioConverter");
-                }
+        if (!self->_audioConverter) {
+            [self ensureAudioConverter];
+            if (self.failed) {
                 return;
             }
         }
@@ -241,24 +238,38 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)requestMediaDataWhenReadyOnQueueInternal:(dispatch_queue_t)queue usingBlock:(RequestHandler)block { [self requestMediaDataWhenReadyOnQueue:queue usingBlock:block]; }
 
+#pragma mark - Private methods
+
+- (void)ensureAudioConverter
+{
+    if (self->_audioConverter) {
+        return;
+    }
+    
+    if (!self.sourceFormat || !self.destinationFormat) {
+        return;
+    }
+    
+    self->_audioConverter = [[AVAudioConverter alloc] initFromFormat:self.sourceFormat toFormat:self.destinationFormat];
+    if (!self->_audioConverter) {
+        self.failed = YES;
+        if (self.verbose) {
+            SecureErrorLog(@"Failed to create AVAudioConverter");
+        }
+    }
+}
+
 - (void)processNextBuffer
 {
     if (_inputBufferQueue.count == 0) {
         return;
     }
 
-    if (!_audioConverter && self.sourceFormat && self.destinationFormat) {
-        _audioConverter = [[AVAudioConverter alloc] initFromFormat:self.sourceFormat toFormat:self.destinationFormat];
+    if (!_audioConverter) {
+        [self ensureAudioConverter];
         if (!_audioConverter) {
-            self.failed = YES;
-            if (self.verbose) {
-                SecureErrorLog(@"Failed to create AVAudioConverter");
-            }
             return;
         }
-    }
-    if (!_audioConverter) {
-        return;
     }
     
     NSValue* value = _inputBufferQueue.firstObject;
@@ -363,7 +374,7 @@ NS_ASSUME_NONNULL_BEGIN
         
         // Wait for semaphore signal indicating new data is available
         // Use a timeout to periodically check for failure state
-        dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_MSEC); // 50ms timeout
+        dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, OUTPUT_POLL_TIMEOUT_MS * NSEC_PER_MSEC);
         dispatch_semaphore_wait(_outputDataSemaphore, timeout);
         
         // Continue the loop to check for data availability and failure state
@@ -373,6 +384,25 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable CMSampleBufferRef)copyNextSampleBufferInternal { return [self copyNextSampleBuffer]; }
+
+#pragma mark - Private methods
+
+- (void)setVolumeDb:(double)volumeDb
+{
+    if (volumeDb < MEAudioConverterMinVolumeDB) {
+        if (self.verbose) {
+            SecureLogf(@"volumeDb clamped from %f to %f (minimum)", volumeDb, MEAudioConverterMinVolumeDB);
+        }
+        _volumeDb = MEAudioConverterMinVolumeDB;
+    } else if (volumeDb > MEAudioConverterMaxVolumeDB) {
+        if (self.verbose) {
+            SecureLogf(@"volumeDb clamped from %f to %f (maximum)", volumeDb, MEAudioConverterMaxVolumeDB);
+        }
+        _volumeDb = MEAudioConverterMaxVolumeDB;
+    } else {
+        _volumeDb = volumeDb;
+    }
+}
 
 @end
 

--- a/movencoder2/Public/METranscoder.h
+++ b/movencoder2/Public/METranscoder.h
@@ -11,10 +11,10 @@
 #ifndef METranscoder_h
 #define METranscoder_h
 
-@import Foundation;
-@import AVFoundation;
-@import VideoToolbox;
-@import CoreAudio;
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+#import <VideoToolbox/VideoToolbox.h>
+#import <CoreAudio/CoreAudioTypes.h>
 
 @class MEManager;
 @class MEInput;

--- a/movencoder2/Public/MEVideoEncoderConfig.h
+++ b/movencoder2/Public/MEVideoEncoderConfig.h
@@ -13,7 +13,7 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreMedia/CoreMedia.h>
-#import "METypes.h"
+#import <MovEncoder2/METypes.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/movencoder2/Public/MovEncoder2.h
+++ b/movencoder2/Public/MovEncoder2.h
@@ -57,17 +57,17 @@
 /**
  * Core Types and Enumerations
  */
-#import "METypes.h"
+#import <MovEncoder2/METypes.h>
 
 /**
  * Type-safe Configuration
  */
-#import "MEVideoEncoderConfig.h"
+#import <MovEncoder2/MEVideoEncoderConfig.h>
 
 /**
  * Main Transcoding Controller
  */
-#import "METranscoder.h"
+#import <MovEncoder2/METranscoder.h>
 
 // MARK: - Public Constants
 

--- a/movencoder2Tests/MEVideoEncoderConfigTests.m
+++ b/movencoder2Tests/MEVideoEncoderConfigTests.m
@@ -8,7 +8,8 @@
 //  SPDX-License-Identifier: GPL-2.0-or-later
 //
 
-#import <XCTest/XCTest.h>
+@import XCTest;
+
 #import "MEVideoEncoderConfig.h"
 #import "MEManager.h"
 

--- a/movencoder2Tests/MEVideoEncoderConfigTests.m
+++ b/movencoder2Tests/MEVideoEncoderConfigTests.m
@@ -10,7 +10,7 @@
 
 @import XCTest;
 
-#import "MEVideoEncoderConfig.h"
+#import "Config/MEVideoEncoderConfig.h"
 #import "MEManager.h"
 
 @interface MEVideoEncoderConfigTests : XCTestCase


### PR DESCRIPTION
## Summary

Fixes commandline tool compilation failure that occurred under Xcode 26.3/26.4 RC, along with related audio converter stability fixes.

## Changes

### Xcode 26.4 RC project update (`ffb7417`)
- **Public headers**: Replace `@import` with `#import` directives — required for module verifier compatibility (`ENABLE_MODULE_VERIFIER = YES`)
- **Umbrella header**: Use framework-style imports (`#import <MovEncoder2/...>`) in `MovEncoder2.h` and `MEVideoEncoderConfig.h`
- **Commandline tool target**: Remove implicit system frameworks (Cocoa, AVFoundation, CoreMedia) from explicit link phase — these were causing SDK resolution failures
- **XCTest.framework**: Fix reference path from `SDKROOT` to `DEVELOPER_DIR` (correct location for XCTest)
- **Project**: Bump `LastUpgradeCheck` to 2640 (Xcode 26.4 RC)
- **Framework target**: Remove hardcoded `MACOSX_DEPLOYMENT_TARGET = 12.0` per-target overrides (inherit from project level)

### MEAudioConverter: buffer pool leak + volume validation (`4a4b046`)
- Fix `audioBufferListPool` leak on reuse
- Add volume dB validation

### MEAudioConverter: synchronous cleanup to avoid dealloc UAF (`5c4d9c7`)
- Use `dispatch_queue_set_specific` / `dispatch_get_specific` to detect current queue context
- Replace `dispatch_async` with `dispatch_sync` in `cleanup` for deterministic, ordered teardown
- Snapshot buffer arrays before releasing outside queue context, eliminating use-after-free on dealloc
- Fixes intermittently cancelled `testVolumeDbZeroNoChangeInt16`